### PR TITLE
Add legal compliance checkbox at sign up 

### DIFF
--- a/rmr/app/privacy-policy/page.tsx
+++ b/rmr/app/privacy-policy/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PrivacyPolicyPage: React.FC = () => {
+    return (
+        <div>
+            <h1>Privacy Policy</h1>
+            <p>This is a placeholder for the Privacy Policy page.</p>
+        </div>
+    );
+};
+
+export default PrivacyPolicyPage;

--- a/rmr/app/terms-of-service/page.tsx
+++ b/rmr/app/terms-of-service/page.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const TermsOfServicePage = () => {
+    return (
+        <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+            <h1>Terms of Service</h1>
+            <p>
+                Welcome to the Terms of Service page. This is a placeholder for the terms and conditions of using our application.
+            </p>
+        </div>
+    );
+};
+
+export default TermsOfServicePage;


### PR DESCRIPTION
Fixes #45 

 Adds a checkbox that links to the Privacy Policy and Terms of Use.

This is updated in the Clerk configurations, so the only changes in this PR are adding dummy TOS and PPolicy pages so that we can have that checkbox.

Will make another PR to add insert this information into the database. (#48)
 
 ---
 
**Testing Instructions:**
- [ ] Cannot sign up without checking the box
- [ ] Can sign up with checking the box
	- [ ] Information in database is the same as before (no changes to functionality of webhook)